### PR TITLE
Add more details to bad topic name errors.

### DIFF
--- a/routemaster/client.rb
+++ b/routemaster/client.rb
@@ -92,7 +92,7 @@ module Routemaster
     end
 
     def _assert_valid_topic(topic)
-      _assert (topic =~ /^[a-z_]{1,32}$/), 'bad topic name'
+      _assert (topic =~ /^[a-z_]{1,64}$/), 'bad topic name: must only include letters and underscores'
     end
 
     def _assert_valid_timestamp(timestamp)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -108,7 +108,7 @@ describe Routemaster::Client do
 
       it 'fails with a bad topic name' do
         topic.replace 'foo123$bar'
-        expect { perform }.to raise_error(ArgumentError)
+        expect { perform }.to raise_error(ArgumentError, 'bad topic name: must only include letters and underscores')
       end
     end
 


### PR DESCRIPTION
This commit adds a human error message when receiving a `bad topic name` error. It also raises the 32 character limitation to 64.
## Rationale

In some cases it's very hard to know what you've done wrong when trying to set up a connection, for instance when setting up topic names these are limited to 32 characters, only latin letters and underscores, but unless you dig into the code a user would never know what's wrong. 

We have better error messages for some other arguments such as `uri`, where the message specifies the requirement for HTTPS.

On that same page why do we set a 32 character limitation? I ran into this problem because my topic name is 33 characters - If we think topics **must** be this short then we can document that and explain why. 
