### PR TITLE
Net http persistent fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     routemaster-client (1.2.2)
       faraday (>= 0.9.0)
-      net-http-persistent (>= 2.9.4)
+      net-http-persistent (~> 2.9.4)
       wisper (>= 1.6.1)
 
 GEM
@@ -97,4 +97,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    routemaster-client (1.2.2)
+    routemaster-client (1.2.3)
       faraday (>= 0.9.0)
       net-http-persistent (~> 2.9.4)
       wisper (>= 1.6.1)

--- a/routemaster-client.gemspec
+++ b/routemaster-client.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(.)
 
   spec.add_runtime_dependency     'faraday', '>= 0.9.0'
-  spec.add_runtime_dependency     'net-http-persistent', '>= 2.9.4'
+  spec.add_runtime_dependency     'net-http-persistent', '~> 2.9.4'
   spec.add_runtime_dependency     'wisper', '>= 1.6.1'
 end

--- a/routemaster/client/version.rb
+++ b/routemaster/client/version.rb
@@ -1,5 +1,5 @@
 module Routemaster
   class Client
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
   end
 end


### PR DESCRIPTION
`routemaster-client` is tested against `net-http-persistent 2.9.4` - 3.0.0 introduces some breaking changes which is causing issues with our `1.2.2` release. For more information check https://github.com/drbrain/net-http-persistent/blob/master/History.txt
