### PR TITLE
IP-426: Payloads in events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# HEAD 
+
+Features: 
+
+- Adds support for event payloads (#16)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ supports this (otherwise an error will be raised):
 Routemaster::Client.updated('widgets', 'https://app.example.com/widgets/2', async: true)
 ```
 
+A data payload can be sent alongside the event. It is strongly discouraged to do
+this except extrame circumstances (particularly as schema migrations become very
+painful):
+
+```ruby
+Routemaster::Client.created('cats', 'https://app.example.com/cats/42', data: { 'color' => 'teal' })
+```
+
 **Subscribe** to be notified about `widgets` and `kitten` at most 60 seconds after
 events, in batches of at most 500 events, to a given callback URL:
 

--- a/routemaster/client.rb
+++ b/routemaster/client.rb
@@ -30,48 +30,48 @@ module Routemaster
         end
       end
 
-      def created(topic, callback, timestamp = nil, t: nil, async: false)
+      def created(topic, callback, timestamp = nil, t: nil, async: false, data: nil)
         _warn_timestamp_deprecation(timestamp)
-        _send_event('create', topic, callback, t: t || timestamp, async: async)
+        _send_event('create', topic, callback, t: t || timestamp, async: async, data: data)
       end
 
-      def created_async(topic, callback, timestamp = nil, t: nil)
+      def created_async(topic, callback, timestamp = nil, t: nil, data: nil)
         _warn_timestamp_deprecation(timestamp)
         _warn_async_deprecation
-        _send_event('create', topic, callback, t: t || timestamp, async: true)
+        _send_event('create', topic, callback, t: t || timestamp, async: true, data: data)
       end
 
-      def updated(topic, callback, timestamp = nil, t: nil, async: false)
+      def updated(topic, callback, timestamp = nil, t: nil, async: false, data: nil)
         _warn_timestamp_deprecation(timestamp)
-        _send_event('update', topic, callback, t: t || timestamp, async: async)
+        _send_event('update', topic, callback, t: t || timestamp, async: async, data: data)
       end
 
-      def updated_async(topic, callback, timestamp = nil, t: nil)
-        _warn_timestamp_deprecation(timestamp)
-        _warn_async_deprecation
-        _send_event('update', topic, callback, t: t || timestamp, async: true)
-      end
-
-      def deleted(topic, callback, timestamp = nil, t: nil, async: false)
-        _warn_timestamp_deprecation(timestamp)
-        _send_event('delete', topic, callback, t: t || timestamp, async: async)
-      end
-
-      def deleted_async(topic, callback, timestamp = nil, t: nil)
+      def updated_async(topic, callback, timestamp = nil, t: nil, data: nil)
         _warn_timestamp_deprecation(timestamp)
         _warn_async_deprecation
-        _send_event('delete', topic, callback, t: t || timestamp, async: true)
+        _send_event('update', topic, callback, t: t || timestamp, async: true, data: data)
       end
 
-      def noop(topic, callback, timestamp = nil, t: nil, async: false)
+      def deleted(topic, callback, timestamp = nil, t: nil, async: false, data: nil)
         _warn_timestamp_deprecation(timestamp)
-        _send_event('noop', topic, callback, t: t || timestamp, async: async)
+        _send_event('delete', topic, callback, t: t || timestamp, async: async, data: data)
       end
 
-      def noop_async(topic, callback, timestamp = nil, t: nil)
+      def deleted_async(topic, callback, timestamp = nil, t: nil, data: nil)
         _warn_timestamp_deprecation(timestamp)
         _warn_async_deprecation
-        _send_event('noop', topic, callback, t: t || timestamp, async: true)
+        _send_event('delete', topic, callback, t: t || timestamp, async: true, data: data)
+      end
+
+      def noop(topic, callback, timestamp = nil, t: nil, async: false, data: nil)
+        _warn_timestamp_deprecation(timestamp)
+        _send_event('noop', topic, callback, t: t || timestamp, async: async, data: data)
+      end
+
+      def noop_async(topic, callback, timestamp = nil, t: nil, data: nil)
+        _warn_timestamp_deprecation(timestamp)
+        _warn_async_deprecation
+        _send_event('noop', topic, callback, t: t || timestamp, async: true, data: data)
       end
 
       def subscribe(topics:, callback:, **options)
@@ -177,13 +177,20 @@ module Routemaster
         end
       end
 
-      def _send_event(event, topic, callback, t: nil, async: false)
+      def _assert_valid_data(value)
+        !! Oj.dump(value, mode: :strict)
+      rescue TypeError => e
+        raise InvalidArgumentError, e
+      end
+
+      def _send_event(event, topic, callback, t: nil, async: false, data: nil)
         _assert_valid_url!(callback)
         _assert_valid_topic!(topic)
         _assert_valid_timestamp!(t) if t
+        _assert_valid_data(data) if data
 
         backend = async ? async_backend : _synchronous_backend
-        backend.send_event(event, topic, callback, t: t)
+        backend.send_event(event, topic, callback, t: t, data: data)
       end
 
       def _check_pulse!

--- a/routemaster/client/connection.rb
+++ b/routemaster/client/connection.rb
@@ -22,12 +22,13 @@ module Routemaster
           _conn.send(method, path, &block)
         end
 
-        def send_event(event, topic, callback, t: nil)
-          payload = { type: event, url: callback, timestamp: t }
+        def send_event(event, topic, callback, t: nil, data: nil)
+          payload = { 'type' => event, 'url' => callback, 'timestamp' => t }
+          payload['data'] = data unless data.nil?
 
           response = post("/topics/#{topic}") do |r|
             r.headers['Content-Type'] = 'application/json'
-            r.body = Oj.dump(_stringify_keys payload)
+            r.body = Oj.dump(payload, mode: :strict)
           end
           fail "event rejected (#{response.status})" unless response.success?
 


### PR DESCRIPTION
This adds publication support for payloads in events.

Server-side changes are at deliveroo/routemaster#74.

-----

Jira story [#IP-426](https://deliveroo.atlassian.net/browse/IP-426) in project *Infrastructure and Platform*:

> ## Why 
> 
> There's a small number of use cases where the "pure RESTful" approach of only sending _events_ on the bus doesn't work (e.g. high-frequency updates where the subscribers might not manage to fetch intermediary representations), and the alternative (storing the history of change on the publisher side) scales very poorly.
> 
> Such an example if the `rider_location` resource, with GPS coordinates changing potentially every 10s.
> 
> ## What
> 
> - Add support for Routemaster to accept and transmit resource representations in JSON form.
> - Amend `routemaster-drain` to cache form the transmitted representations if present (bypassing the API querying).
> - Set a hard limit on representation sizes, defaulting to 64 bytes.