### PR TITLE
SETI-371: Routemaster client does not send timestamp when async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+Bug fixes:
+
+- Always send a timestamp when sending asynchronously (#20)
+
 # v3.1.0 (2017-03-28) 
 
 Features: 

--- a/routemaster/client.rb
+++ b/routemaster/client.rb
@@ -189,6 +189,7 @@ module Routemaster
         _assert_valid_timestamp!(t) if t
         _assert_valid_data(data) if data
 
+        t ||= _now if async
         backend = async ? async_backend : _synchronous_backend
         backend.send_event(event, topic, callback, t: t, data: data)
       end
@@ -209,6 +210,11 @@ module Routemaster
         warn 'routemaster-client: Passing timestamps as positional parameters is deprecated. Use the t: key instead.'
         warn "(in #{caller(2,1).first})"
       end
+
+      def _now
+        (Time.now.to_f * 1e3).to_i
+      end
+
 
       private :async_backend, :lazy
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -69,7 +69,7 @@ describe Routemaster::Client do
     end
   end
 
-  shared_examples 'an event sender' do
+  shared_examples 'an event sender' do |o|
     let(:callback) { 'https://app.example.com/widgets/123' }
     let(:topic)    { 'widgets' }
     let(:perform)  { subject.send(method, topic, callback, **flags) }
@@ -104,6 +104,16 @@ describe Routemaster::Client do
           expect(data['url']).to eq callback
         end
         perform
+      end
+
+      if o && o[:set_timestamp]
+        it 'sets a timestamp' do
+          @stub.with do |req|
+            data = JSON.parse(req.body)
+            expect(data['timestamp']).to be_a_kind_of(Integer)
+          end
+          perform
+        end
       end
 
       it 'fails with a bad callback URL' do
@@ -275,7 +285,7 @@ describe Routemaster::Client do
         describe "##{m}" do
           let(:method) { m }
           let(:event) { m.sub(/d$/, '') }
-          it_behaves_like 'an event sender'
+          it_behaves_like 'an event sender', set_timestamp: true
         end
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -69,7 +69,7 @@ describe Routemaster::Client do
     end
   end
 
-  shared_examples 'an event sender' do |o|
+  shared_examples 'an event sender' do |spec_options|
     let(:callback) { 'https://app.example.com/widgets/123' }
     let(:topic)    { 'widgets' }
     let(:perform)  { subject.send(method, topic, callback, **flags) }
@@ -106,7 +106,7 @@ describe Routemaster::Client do
         perform
       end
 
-      if o && o[:set_timestamp]
+      if spec_options && spec_options[:set_timestamp]
         it 'sets a timestamp' do
           @stub.with do |req|
             data = JSON.parse(req.body)


### PR DESCRIPTION
Automatically set a timestamp on events when sending asynchronously.

===

Jira story [#SETI-371](https://deliveroo.atlassian.net/browse/SETI-371) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> We just switched `orderweb` to sending bus events asynchronously, which means they'll reach clients (a bit) later.
> 
> When sending events synchronously, we do not set a timestamp on events and the bus assumes the reception timestamp.
> 
> When sending async, we _still_ do not set a timestamp, but given the potential for extra delay this might be much more incorrect.
> 
> ## What
> 
> Set a timestamp on events when sending async.