### PR TITLE
fix parsing latency and batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.3 (2018-01-08)
+
+Bug fixes:
+
+- Fix crash when specifying latency and batch size for subscriptions (#29)
+
 ## 3.1.2 (2018-01-05)
 
 Bug fixes:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    routemaster-client (3.1.2)
+    routemaster-client (3.1.3)
       faraday (>= 0.9.0)
       hashie
       oj (~> 2.17)

--- a/routemaster/cli/base.rb
+++ b/routemaster/cli/base.rb
@@ -33,6 +33,16 @@ module Routemaster
         def action(&block)
           block_given? ? (@action = block) : @action || lambda { |*| }
         end
+
+        def config
+          @config ||= Hashie::Mash.new(_default_options).merge(defaults)
+        end
+
+        private
+
+        def _default_options
+          { verbose: false }
+        end
       end
 
       def initialize(stderr:, stdout:)
@@ -61,7 +71,7 @@ module Routemaster
       end
 
       def config
-        @config ||= Hashie::Mash.new(_default_options).merge(self.class.defaults)
+        self.class.config
       end
 
       def helper
@@ -88,10 +98,6 @@ module Routemaster
       end
 
       private
-
-      def _default_options
-        { verbose: false }
-      end
 
       def _parser
         @parser ||= OptionParser.new do |p|

--- a/routemaster/client/version.rb
+++ b/routemaster/client/version.rb
@@ -1,5 +1,5 @@
 module Routemaster
   module Client
-    VERSION = '3.1.2'
+    VERSION = '3.1.3'
   end
 end

--- a/spec/cli/sub_spec.rb
+++ b/spec/cli/sub_spec.rb
@@ -7,10 +7,10 @@ describe Routemaster::CLI::Sub, type: :cli do
 
   describe 'add' do
     context 'with correct arguments' do
-      let(:argv) { %w[sub add https://my-service.dev cats dogs -b bus.dev -t s3cr3t] }
+      let(:argv) { %w[sub add https://my-service.dev cats dogs -b bus.dev -t s3cr3t --latency 500] }
 
       it {
-        expect(client).to receive(:subscribe).with(topics: %w[cats dogs], callback: 'https://my-service.dev', uuid: 's3cr3t')
+        expect(client).to receive(:subscribe).with(topics: %w[cats dogs], callback: 'https://my-service.dev', uuid: 's3cr3t', timeout: 500)
         perform
       }
     end


### PR DESCRIPTION
There was an issue of mismatching scopes when an inner block was being
configured. This was easily resolved by moving a configuration variable
to the class level for the `Routemaster::CLI::Sub::Base` class. Since
the commands will be run individually, class-level configuration changes
wouldn't mean much and they will all be done from scratch for each run.