### PR TITLE
Fixes out of scope config

### DIFF
--- a/routemaster/cli/base.rb
+++ b/routemaster/cli/base.rb
@@ -100,7 +100,7 @@ module Routemaster
 
           if self.class.options
             p.separator 'Options:'
-            self.class.options.call(p)
+            instance_exec(p, &self.class.options)
           end
 
           p.separator 'Common options:'

--- a/spec/cli/sub_spec.rb
+++ b/spec/cli/sub_spec.rb
@@ -7,10 +7,18 @@ describe Routemaster::CLI::Sub, type: :cli do
 
   describe 'add' do
     context 'with correct arguments' do
-      let(:argv) { %w[sub add https://my-service.dev cats dogs -b bus.dev -t s3cr3t] }
+      let(:argv) do
+        %w[sub add https://my-service.dev cats dogs -b bus.dev -t s3cr3t --batch-size 30 --latency 200]
+      end
 
       it {
-        expect(client).to receive(:subscribe).with(topics: %w[cats dogs], callback: 'https://my-service.dev', uuid: 's3cr3t')
+        expect(client).to receive(:subscribe).with(
+          topics: %w[cats dogs],
+          callback: 'https://my-service.dev',
+          uuid: 's3cr3t',
+          max: 30,
+          timeout: 200
+        )
         perform
       }
     end


### PR DESCRIPTION
The routemaster CLI had a bug that given an "options" block, the self of block was pointing to the class itself which meant that setting things on config did not work:

```ruby
options do |p|
   ...
   config # blows
end
```

This changes the call to be `instance_exec` which sets the self within the block to be an instance of parser class but also adds "p" as the argument of the block
 