### PR TITLE
Fix NoMethodError running rtm token list when there are no tokens

### DIFF
--- a/routemaster/cli/token.rb
+++ b/routemaster/cli/token.rb
@@ -42,8 +42,14 @@ module Routemaster
         action do
           bad_argc! unless argv.length == 0
 
-          helper.client.token_list.each do |t,n|
-            puts "#{t}\t#{n}"
+          token_list = helper.client.token_list
+
+          if token_list.empty?
+            puts 'No tokens have been added.'
+          else
+            helper.client.token_list.each do |t,n|
+              puts "#{t}\t#{n}"
+            end
           end
         end
       end

--- a/routemaster/client.rb
+++ b/routemaster/client.rb
@@ -142,7 +142,10 @@ module Routemaster
 
       def token_list
         response = _conn.get("/api_tokens")
+
         raise ConnectionError, "Failed to list tokens (status: #{response.status})" unless response.success?
+        return {} if response.body.empty?
+
         Oj.load(response.body).each_with_object({}) do |entry, result|
           result[entry['token']] = entry['name']
         end

--- a/spec/cli/token_spec.rb
+++ b/spec/cli/token_spec.rb
@@ -46,5 +46,16 @@ describe Routemaster::CLI::Token, type: :cli do
         expect { perform }.to change { stdout.string }.to "service--t0ken\tservice\n"
       }
     end
+
+    context 'when the server token list is empty' do
+      let(:argv) { %w[token list -b bus.dev -t s3cr3t] }
+      before {
+        allow(client).to receive(:token_list).and_return({})
+      }
+
+      it {
+        expect { perform }.to change { stdout.string }.to "No tokens have been added.\n"
+      }
+    end
   end
 end


### PR DESCRIPTION
When there are no tokens you would get

```
$ rtm token list -b @local
NoMethodError: undefined method `each_with_object' for nil:NilClass
```

Now you get

```
$ rtm token list -b @local
No tokens have been added
```