### PR TITLE
Bump the oj version requirements.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     routemaster-client (3.2.0)
       faraday (>= 0.9.0)
       hashie
-      oj (>= 2.17)
+      oj (>= 3)
       typhoeus (~> 1.1)
       wisper (~> 1.6.1)
 
@@ -25,7 +25,7 @@ GEM
     docile (1.1.5)
     ethon (0.11.0)
       ffi (>= 1.3.0)
-    faraday (0.13.1)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     formatador (0.2.5)
@@ -57,7 +57,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oj (3.3.10)
+    oj (3.5.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -130,4 +130,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/routemaster-client.gemspec
+++ b/routemaster-client.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'typhoeus', '~> 1.1'
   spec.add_runtime_dependency     'faraday', '>= 0.9.0'
   spec.add_runtime_dependency     'wisper', '~> 1.6.1'
-  spec.add_runtime_dependency     'oj', '>= 2.17'
+  spec.add_runtime_dependency     'oj', '>= 3'
   spec.add_runtime_dependency     'hashie'
 end


### PR DESCRIPTION
 It was already using 3.3, but the 2.17 declaration was causing compatibility issues with fast_jsonapi.