### PR TITLE
PRODENG-XXX: expand subscription attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## HEAD
+
+Bug fixes:
+
+- Subscription now includes max_events and timeout details so they
+  get printed
+- `$LOAD_PATH` is fixed so `./exe/rtm` can now be run directly
+
 ## 3.2.0 (2018-01-08)
 
 Changes:

--- a/exe/rtm
+++ b/exe/rtm
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+dir = File.expand_path('..', __dir__)
+$LOAD_PATH.unshift(dir) unless $LOAD_PATH.include?(dir)
+
 require 'rubygems'
 require 'routemaster/cli/top_level'
 

--- a/routemaster/client/subscription.rb
+++ b/routemaster/client/subscription.rb
@@ -7,6 +7,8 @@ module Routemaster
       def initialize(options)
         @subscriber = options.fetch('subscriber')
         @callback   = options.fetch('callback')
+        @max_events = options['max_events']
+        @timeout    = options['timeout']
         @topics     = options.fetch('topics')
         @events     = _symbolize_keys options.fetch('events')
       end
@@ -15,8 +17,10 @@ module Routemaster
         {
           subscriber: @subscriber,
           callback:   @callback,
+          max_events: @max_events,
+          timeout:    @timeout,
           topics:     @topics,
-          events:     @events
+          events:     @events,
         }
       end
 

--- a/spec/client/subscription_spec.rb
+++ b/spec/client/subscription_spec.rb
@@ -3,15 +3,17 @@ require 'routemaster/client/subscription'
 
 describe Routemaster::Client::Subscription do
   describe '#initialize' do
-    let(:options) {{ 
-      'subscriber' => 'alice', 
+    let(:options) {{
+      'subscriber' => 'alice',
       'callback'   => 'https://example.com/events',
+      'max_events' => 100,
+      'timeout'    => 500,
       'topics'     => %w[widgets],
       'events'     => {},
     }}
 
     subject { described_class.new(options) }
-    
+
     it 'passes' do
       expect { subject }.not_to raise_error
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -489,7 +489,9 @@ describe Routemaster::Client do
           subscriber: 'bob',
           callback:   'https://app.example.com/events',
           topics:     ['widgets', 'kitten'],
-          events:     { sent: 1, queued: 100, oldest: 10_000 }
+          events:     { sent: 1, queued: 100, oldest: 10_000 },
+          max_events: nil,
+          timeout:    nil,
         }]
       end
 
@@ -510,7 +512,7 @@ describe Routemaster::Client do
       end
     end
   end
-  
+
   describe '#reset_connection' do
     context 'can reset class vars to change params' do
       let(:instance_uuid) { SecureRandom.uuid }
@@ -520,15 +522,15 @@ describe Routemaster::Client do
           verify_ssl: false,
           lazy: true
       }}
-      
+
       before do
           Routemaster::Client::Connection.reset_connection
           @stub = stub_request(:get, 'https://@bus.example.com/topics').with({basic_auth: [instance_uuid, 'x']})
           .to_return(status: 200, body: [{ name: "topic.name", publisher: "topic.publisher", events: "topic.get_count" }].to_json)
       end
-      
+
       after { Routemaster::Client::Connection.reset_connection }
-      
+
       it 'connects with new params' do
           subject.monitor_topics
           expect(@stub).to have_been_requested


### PR DESCRIPTION
Routemaster's API response for `GET /subscribers` [now includes][0]
`max_events` and `timeout` in the JSON. However, these get ignored
in the output of `rtm sub list` because our local description of
`Subscription` does not have these attributes. This PR fixes that
along with fixing the direct running of `./exe/rtm` from the gem
folder.

[0]: https://github.com/deliveroo/routemaster/pull/123