### PR TITLE
display UUID when indexing subscribers

### DIFF
--- a/routemaster/client/subscription.rb
+++ b/routemaster/client/subscription.rb
@@ -6,6 +6,7 @@ module Routemaster
 
       def initialize(options)
         @subscriber = options.fetch('subscriber')
+        @uuid       = options.fetch('uuid')
         @callback   = options.fetch('callback')
         @max_events = options['max_events']
         @timeout    = options['timeout']
@@ -16,6 +17,7 @@ module Routemaster
       def attributes
         {
           subscriber: @subscriber,
+          uuid:       @uuid,
           callback:   @callback,
           max_events: @max_events,
           timeout:    @timeout,

--- a/spec/cli/sub_spec.rb
+++ b/spec/cli/sub_spec.rb
@@ -49,6 +49,7 @@ describe Routemaster::CLI::Sub, type: :cli do
         allow(client).to receive(:monitor_subscriptions).and_return([
           Routemaster::Client::Subscription.new(
             'subscriber' => 'service--f000-b44r-b44r',
+            'uuid' => 'service--af000-b44r-b44r',
             'callback' => 'https://serviced.dev',
             'topics' => %w[cats dogs],
             'events' => {

--- a/spec/client/subscription_spec.rb
+++ b/spec/client/subscription_spec.rb
@@ -5,6 +5,7 @@ describe Routemaster::Client::Subscription do
   describe '#initialize' do
     let(:options) {{
       'subscriber' => 'alice',
+      'uuid'       => 'sub-one--12345',
       'callback'   => 'https://example.com/events',
       'max_events' => 100,
       'timeout'    => 500,

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -487,6 +487,7 @@ describe Routemaster::Client do
       let(:expected_result) do
         [{
           subscriber: 'bob',
+          uuid:       'service--af000-b44r-b44r',
           callback:   'https://app.example.com/events',
           topics:     ['widgets', 'kitten'],
           events:     { sent: 1, queued: 100, oldest: 10_000 },
@@ -500,7 +501,7 @@ describe Routemaster::Client do
 
         it 'expects a collection of subscriptions' do
           expect(perform.map(&:attributes)).to eql(expected_result)
-      end
+        end
       end
 
       context 'the connection to the bus errors' do


### PR DESCRIPTION
Merge after the following PR has been merged and deployed:

https://github.com/deliveroo/routemaster/pull/141

Already tested on staging with the following command locally and
received satisfactory results:

```
./exe/bin sub list -b @staging
```

(the response included the `uuid` detail for each subscriber)